### PR TITLE
Explicitly state the directory name instead of using $_

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -74,7 +74,7 @@ kidx = base + ".kidx"
 
 index_path = 'indices/' + species + '/' + str(kmer_size) + '/'
 
-kallisto_index_shell =  'mkdir -p ' + index_path + ' && cd $_ && ' 
+kallisto_index_shell =  'mkdir -p ' + index_path + ' && cd ' + index_path + ' && '
 kallisto_index_shell += 'kallisto index -k ' + str(kmer_size) + ' '
 kallisto_index_shell += '-i ' + kidx + ' ../../../transcriptome/{base}.fa'
 


### PR DESCRIPTION
With $_ an error occures in some environments. This can be tested by
taking the following Dockerfile

https://gist.github.com/konrad/253e18979b5fcd084dbb0b9f3e72334d

and performing an analysis in a container constructed based on it.

```
$ wget https://gist.githubusercontent.com/konrad/253e18979b5fcd084dbb0b9f3e72334d/raw/f415e36a76565538aac530a5a793c6f858524742/Dockerfile
$ docker build -t lair_test .
$ docker run -t -i lair_test /bin/bash
```

Inside of the container run one test analysis - e.g.
`# snakemake -p --configfile Ayers_10.1186_gb-2013-14-3-r26/config.json`

which will generate the following output ending with an error message:

```
Provided cores: 1
Rules claiming more threads will be scaled down.
Job counts:
        count   jobs
        8       fastq_dump
        1       get_transcriptome
        8       fastq_dump
        1       get_transcriptome
        1       index
        8       kallisto
        1       sleuth
        19
rule get_transcriptome:
        output: transcriptome/Gallus_gallus.Galgal4.cdna.all.fa
cd transcriptome && wget -O Gallus_gallus.Galgal4.cdna.all.fa.gz ftp://ftp.ensembl.org/pub/release-80/fasta/gallus_gallus/cdna/Gallus_gallus.Galgal4.cdna.all.fa.gz && gunzip Gallus_gallus.Galgal4.cdna.all.fa.gz
--2016-08-03 19:15:56--  ftp://ftp.ensembl.org/pub/release-80/fasta/gallus_gallus/cdna/Gallus_gallus.Galgal4.cdna.all.fa.gz
           => 'Gallus_gallus.Galgal4.cdna.all.fa.gz'
Resolving ftp.ensembl.org (ftp.ensembl.org)... 193.62.203.85
Connecting to ftp.ensembl.org (ftp.ensembl.org)|193.62.203.85|:21... connected.
Logging in as anonymous ... Logged in!
==> SYST ... done.    ==> PWD ... done.
==> TYPE I ... done.  ==> CWD (1) /pub/release-80/fasta/gallus_gallus/cdna ... done.
==> SIZE Gallus_gallus.Galgal4.cdna.all.fa.gz ... 13325481
==> PASV ... done.    ==> RETR Gallus_gallus.Galgal4.cdna.all.fa.gz ... done.
Length: 13325481 (13M) (unauthoritative)

Gallus_gallus.Galgal4.cdna.all.fa.gz  100%[=======================================================================>]  12.71M  8.73MB/s    in 1.5s    

2016-08-03 19:15:58 (8.73 MB/s) - 'Gallus_gallus.Galgal4.cdna.all.fa.gz' saved [13325481]
1 of 19 steps (5%) done
rule index:
        input: transcriptome/Gallus_gallus.Galgal4.cdna.all.fa
        output: indices/gallus_gallus/31/Gallus_gallus.Galgal4.cdna.all.kidx
mkdir -p indices/gallus_gallus/31/ && cd $_ && kallisto index -k 31 -i Gallus_gallus.Galgal4.cdna.all.kidx ../../../transcriptome/Gallus_gallus.Galgal4.cdna.all.fa
/bin/sh: 1: cd: can't cd to /usr/bin/snakemake
Error in job index while creating output file indices/gallus_gallus/31/Gallus_gallus.Galgal4.cdna.all.kidx.
RuleException:
CalledProcessError in line 149 of /root/bears_analyses/Snakefile:
Command 'mkdir -p indices/gallus_gallus/31/ && cd $_ && kallisto index -k 31 -i Gallus_gallus.Galgal4.cdna.all.kidx ../../../transcriptome/Gallus_gallus.Galgal4.cdna.all.fa' returned non-zero exit status 2
  File "/root/bears_analyses/Snakefile", line 149, in __rule_index
  File "/usr/lib/python3.5/concurrent/futures/thread.py", line 55, in run
Will exit after finishing currently running jobs.
Exiting because a job execution failed. Look above for error message
```
